### PR TITLE
Fix urgency of Risk Notables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 PipFile**
+.vscode

--- a/docs/searches/fix_urgency.md
+++ b/docs/searches/fix_urgency.md
@@ -1,0 +1,16 @@
+# Fix Urgency for Risk Notables
+
+!!! tip "See the full walkthrough at [https://zachthesplunker.com/risk-notable-urgency/](https://zachthesplunker.com/risk-notable-urgency/){ target="_blank" }"
+
+By default, a risk object's priority is not taken into account for the Urgency of a Notable event, even if it is configured in the A&I database. 
+
+The Urgency field is a combination of an Asset/Identity's priority plus the severity of the event. The default Urgency Lookup can be found in Content Management in the Enterprise Security App.
+
+## Simple Fix
+
+```sh title="SPL to append to Risk Notables" linenums="1"
+...
+| eval 
+    user=case(risk_object_type=="user", risk_object),
+    src=case(isnull(user), risk_object)
+```

--- a/docs/searches/index.md
+++ b/docs/searches/index.md
@@ -27,3 +27,7 @@ ADDITIONALLY, this frees risk_message to be used as a short and sweet summary ra
 ## [Chaining behaviors](./this_then_that_alerts.md)
 
 This is some simple SPL to organize risk events by risk_object and create risk rules which look for a specific sequence of events or chain of behaviors.
+
+## [Fix Urgency for Risk Notables](./fix_urgency.md)
+
+By default, a risk object's priority is not taken into account for the Urgency of a Notable event, even if it is configured in the A&I database. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - Essential RBA searches: searches/risk_guide_searches.md
       - Risk info field: searches/risk_info_event_detail.md
       - Chaining behaviors: searches/this_then_that_alerts.md
+      - Fix Urgency for Risk Notables: searches/fix_urgency.md
   - Dashboards:
       - dashboards/index.md
       - Att&CK Matrix Risk: dashboards/attack_matrix_risk.md


### PR DESCRIPTION
By default, a risk object's priority is not taken into account for the Urgency of a Notable event, even if it is configured in the A&I database. 