### PR TITLE
Issue 102

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 PipFile**
+.DS_Store

--- a/dashboards/attack_matrix_risk.xml
+++ b/dashboards/attack_matrix_risk.xml
@@ -1,5 +1,4 @@
-<!-- Initial dashboard created by the wonderful Jim Apger -->
-<form script="mitre_matrix.js" stylesheet="mitre_matrix.css" theme="light" version="1.1">
+<!-- Initial dashboard created by the wonderful Jim Apger --><form script="mitre_matrix.js" stylesheet="mitre_matrix.css" theme="light" version="1.1">
   <label>ATT&amp;CK Matrix Risk (Business View)</label>
   <description>This dashboard portraoys risk in your environment through the lens of RBA and the MITRE ATT&amp;CK framework</description>
   <search id="mitre_base_1">
@@ -24,10 +23,12 @@
       <single>
         <title>Reduction in notables by using the Attribution based approach</title>
         <search>
-          <query>index=notable|eval notable=if(eventtype="risk_notables","Risk Notable","Notable")|stats count by notable
-|transpose 0 header_field=notable
-|eval p=round(100-('Risk Notable'/Notable)*100,1)
-|table p</query>
+          <query>index=notable 
+| eval notable=if(eventtype="risk_notables","Risk Notable","Notable") 
+| stats count by notable 
+| transpose 0 header_field=notable 
+| eval p=round(100-('Risk Notable'/Notable)*100,1) 
+| table p</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -45,8 +46,9 @@
       <chart>
         <title>Traditional Notables versus Risk Notables</title>
         <search>
-          <query>index=notable|eval notable=if(eventtype="risk_notables","Risk Notable","Notable")
-|timechart span=1h count by notable</query>
+          <query>index=notable 
+| eval notable=if(eventtype="risk_notables","Risk Notable","Notable") 
+| timechart span=1h count by notable</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>
@@ -83,7 +85,7 @@
       <single>
         <search>
           <query>`notable`
-| search search_name="Threat - ATT&amp;CK*"
+| search eventtype="risk_notables"
 | stats count</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
@@ -100,19 +102,35 @@
   </row>
   <row>
     <panel>
+      <input type="dropdown" token="tokDetectionStatus" searchWhenChanged="true">
+        <label>Detection Status</label>
+        <choice value="disabled=*">ALL</choice>
+        <choice value="disabled=0">Enabled</choice>
+        <choice value="disabled=1">Disabled</choice>
+        <default>disabled=0</default>
+        <initialValue>disabled=0</initialValue>
+      </input>
       <table>
         <title>Techniques Covered in Our Environment</title>
         <search>
-          <query>|inputlookup mitre_attack_lookup
-| stats dc(mitre_technique_id) as total_techniques by mitre_tactic
-|append [| rest splunk_server=local count=0 /services/saved/searches|search action.correlationsearch.label="RR - *"|table action.correlationsearch.annotations|spath input=action.correlationsearch.annotations|rename mitre_attack{} as  mitre_technique_id|mvexpand mitre_technique_id|lookup mitre_attack_lookup mitre_technique_id OUTPUT mitre_tactic|stats dc(mitre_technique_id) as num_covered_techniques by mitre_tactic]|stats values(total_techniques) as total_techniques, values(num_covered_techniques) as num_covered_techniques by mitre_tactic
-| fillnull value="0" num_covered_techniques
-| eval combo = num_covered_techniques." of ".total_techniques
-|eval perc=round((num_covered_techniques/total_techniques)*100,1)
-|eval perc="(".perc."%)"
-|table mitre_tactic, combo,perc
-| transpose 0 header_field=mitre_tactic
-|fields - column</query>
+          <query>| inputlookup mitre_attack_lookup 
+| stats dc(mitre_technique_id) as total_techniques by mitre_tactic 
+| append 
+    [| rest splunk_server=local count=0 /services/saved/searches f=actions f=action.correlationsearch.enabled f=action.correlationsearch.annotations f=disabled
+    | where isnotnull('action.correlationsearch.enabled') AND match(actions, "risk") AND $tokDetectionStatus$
+    | spath input=action.correlationsearch.annotations 
+    | rename mitre_attack{} as mitre_technique_id 
+    | mvexpand mitre_technique_id 
+    | lookup mitre_attack_lookup mitre_technique_id OUTPUT mitre_tactic 
+    | stats dc(mitre_technique_id) as num_covered_techniques by mitre_tactic] 
+| stats values(total_techniques) as total_techniques, values(num_covered_techniques) as num_covered_techniques by mitre_tactic 
+| fillnull value="0" num_covered_techniques 
+| eval combo = num_covered_techniques." of ".total_techniques 
+| eval perc=round((num_covered_techniques/total_techniques)*100,1) 
+| eval perc="(".perc."%)" 
+| table mitre_tactic, combo,perc 
+| transpose 0 header_field=mitre_tactic 
+| fields - column</query>
           <earliest>$field1.earliest$</earliest>
           <latest>$field1.latest$</latest>
         </search>

--- a/dashboards/audit_attribution_analytics.xml
+++ b/dashboards/audit_attribution_analytics.xml
@@ -1,5 +1,4 @@
-<!-- Initial dashboard created by the wonderful Jim Apger -->
-<form version="1.1">
+<!-- Initial dashboard created by the wonderful Jim Apger --><form version="1.1">
   <label>Audit:  Attribution Analytics (Tuning View)</label>
   <description>Helpful for tuning new detections</description>
   <fieldset submitButton="false" autoRun="true">
@@ -158,9 +157,11 @@
           <earliest>$time_picker.earliest$</earliest>
           <latest>$time_picker.latest$</latest>
         </search>
+        <option name="charting.axisLabelsX.majorLabelStyle.rotation">-45</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.overlayFields">"Risk Threshold"</option>
         <option name="charting.drilldown">none</option>
+        <option name="height">444</option>
       </chart>
     </panel>
     <panel>
@@ -172,9 +173,11 @@
           <earliest>$time_picker.earliest$</earliest>
           <latest>$time_picker.latest$</latest>
         </search>
+        <option name="charting.axisLabelsX.majorLabelStyle.rotation">-45</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.overlayFields">"Risk Threshold"</option>
         <option name="charting.drilldown">none</option>
+        <option name="height">445</option>
         <option name="refresh.display">progressbar</option>
       </chart>
     </panel>
@@ -186,9 +189,11 @@
           <earliest>$time_picker.earliest$</earliest>
           <latest>$time_picker.latest$</latest>
         </search>
+        <option name="charting.axisLabelsX.majorLabelStyle.rotation">-45</option>
         <option name="charting.chart">column</option>
         <option name="charting.chart.overlayFields">"Risk Threshold"</option>
         <option name="charting.drilldown">none</option>
+        <option name="height">444</option>
         <option name="refresh.display">progressbar</option>
       </chart>
     </panel>
@@ -202,8 +207,7 @@
 | extract pairdelim=",", kvdelim="=", auto=f 
 | stats avg(result_count) as avg_results max(result_count) as max_results sparkline avg(run_time) as avg_runtime max(run_time) as max_runtime count AS execution_count by savedsearch_name, app 
 | join savedsearch_name type=outer 
-    [| rest splunk_server=local /servicesNS/-/-/saved/searches 
-    | fields title description eai:acl.app eai:acl.sharing eai:acl.owner cron_schedule dispatch.earliest_time dispatch.latest_time, disabled actions 
+    [| rest splunk_server=local /servicesNS/-/-/saved/searches f=title f=description f=eai* f=cron_schedule f=dispatch.earliest_time f=dispatch.latest_time f=disabled f=actions 
     | rename title AS savedsearch_name eai:acl.app AS App eai:acl.owner AS Owner cron_schedule AS "Cron Schedule" dispatch.earliest_time AS "Dispatch Earliest Time" dispatch.latest_time AS "Dispatch Latest Time" actions AS "Adaptive Response Actions", eai:acl.sharing AS Sharing] 
     
 |eval comment="This is just to make the demo work below since we do not have execution results in _internal"

--- a/dashboards/rba_data_source_overview.xml
+++ b/dashboards/rba_data_source_overview.xml
@@ -1,35 +1,35 @@
 <form theme="dark" version="1.1">
   <label>RBA Data Source Review</label>
   <search id="basesearch">
-    <query>| rest splunk_server=local count=0 /servicesNS/-/SplunkEnterpriseSecuritySuite/saved/searches
-| where match('action.correlationsearch.enabled', "1|[Tt]|[Tt][Rr][Uu][Ee]")
-| where disabled=0
-| eval actions=split(actions, ",")
-| rename  action.risk.param._risk as risk_param action.risk.param._risk_object_type as risk_object_type0 action.risk.param._risk_object as risk_object0 action.risk.param._risk_score as risk_score0
+    <query>| rest splunk_server=local count=0 /servicesNS/-/SplunkEnterpriseSecuritySuite/saved/searches f=disabled f=title f=search f=actions f=action.correlationsearch.enabled f=action.correlationsearch.annotations f=action.risk.param._risk f=action.risk.param._risk_object
+| where match('action.correlationsearch.enabled', "1|[Tt]|[Tt][Rr][Uu][Ee]") AND match('actions',"risk") AND disabled=0
 | rex field=search "index=(?&lt;index&gt;.+?)\s"
-| rex field=search "sourcetype=(?&lt;sourcetype&gt;.+?)\s"
 | rex field=search "datamodel:?\W?(?&lt;datamodel&gt;\w+)"
-| rex field=search "mitre_tactic=(?&lt;mitre_tactic&gt;.+)"
-| rex field=search "mitre_technique=(?&lt;mitre_technique&gt;.+)"
-| eval index=replace(index,"\"","")
 | eval data_source=coalesce(index, datamodel)
+| spath input=action.correlationsearch.annotations
+| spath input=action.risk.param._risk
+| rename mitre_attack{} as mitre_technique, {}.risk_object_field as risk_object_field
+| eval risk_object = coalesce(risk_object_field, 'action.risk.param._risk_object')
+| fields - risk_object_field, action.risk.param._risk_object
+| lookup mitre_attack_lookup mitre_technique_id as mitre_technique OUTPUT mitre_tactic_id as mitre_tactic
          </query>
     <earliest>-1h</earliest>
     <latest>now</latest>
     <sampleRatio>1</sampleRatio>
   </search>
-  <fieldset submitButton="false"></fieldset>
+  <fieldset submitButton="false" autoRun="true"></fieldset>
   <row>
     <panel>
       <title>Risk Rules</title>
       <single>
         <title>Detections that populate the Risk index</title>
         <search base="basesearch">
-          <query>|  stats  dc(title) as Risk_Detections</query>
+          <query>| stats dc(title) as Risk_Detections</query>
         </search>
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
         <option name="drilldown">none</option>
+        <option name="height">230</option>
         <option name="numberPrecision">0</option>
         <option name="rangeColors">["0x53a051", "0x0877a6", "0xf8be34", "0xf1813f", "0xdc4e41"]</option>
         <option name="rangeValues">[0,30,70,100]</option>
@@ -94,7 +94,9 @@
       <title>Technique Overview</title>
       <chart>
         <search base="basesearch">
-          <query>| stats count by mitre_technique</query>
+          <query>| lookup mitre_attack_lookup mitre_technique_id as mitre_technique OUTPUT mitre_technique as mitre_technique_label
+| eval mitre_technique = mitre_technique + " - " + mitre_technique_label
+| stats count by mitre_technique</query>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
@@ -135,7 +137,9 @@
       <title>Tactic Overview</title>
       <chart>
         <search base="basesearch">
-          <query>| stats count by mitre_tactic</query>
+          <query>| lookup mitre_attack_lookup mitre_tactic_id as mitre_tactic OUTPUT mitre_tactic_label
+| eval mitre_tactic = mitre_tactic + " - " + mitre_tactic_label
+| stats count by mitre_tactic</query>
         </search>
         <option name="charting.axisLabelsX.majorLabelStyle.overflowMode">ellipsisNone</option>
         <option name="charting.axisLabelsX.majorLabelStyle.rotation">0</option>
@@ -175,10 +179,16 @@
   </row>
   <row>
     <panel>
-      <title>Risk Rules by Data Source</title>
+      <title>Risk Rules by Data Model</title>
       <table>
         <search base="basesearch">
-          <query>| stats values(title) as Risk_Rule, values(mitre_tactic) as mitre_tactic values(mitre_technique) as mitre_technique by data_source</query>
+          <query>| rex field=search "index=(?&lt;index&gt;.+?)\s"
+| rex field=search "datamodel:?\W?(?&lt;datamodel&gt;\w+)"
+| eval data_source=coalesce(index, datamodel)
+| spath input=action.correlationsearch.annotations
+| rename mitre_attack{} as mitre_technique
+| lookup mitre_attack_lookup mitre_technique_id as mitre_technique OUTPUT mitre_tactic_id as mitre_tactic
+| stats values(title) as Risk_Rule, values(mitre_tactic) as mitre_tactic values(mitre_technique) as mitre_technique by data_source</query>
         </search>
         <option name="count">10</option>
         <option name="dataOverlayMode">none</option>
@@ -191,26 +201,22 @@
       </table>
     </panel>
     <panel>
-      <title>Risk Data Source Event Overview</title>
+      <title>Risk Data Source Event Overview - Last 60 minutes</title>
       <table>
         <search base="basesearch">
-          <query>
-| eval source=title
-
-| join type=left source
- [search index=risk source=* 
- | stats count as total_events earliest(_time) as first_seen last(_time) as last_seen by source ]
-
-| table title mitre_technique mitre_tactic first_seen last_seen total_events
-
-| fieldformat first_seen=strftime(first_seen, "%c")
-| fieldformat last_seen=strftime(last_seen, "%c")
+          <query>| eval source=title 
+| join type=left source 
+    [| tstats count as total_events min(_time) as first_seen max(_time) as last_seen WHERE index=risk by source ] 
+| table title mitre_technique mitre_tactic first_seen last_seen total_events 
+| fieldformat first_seen=strftime(first_seen, "%c") 
+| fieldformat last_seen=strftime(last_seen, "%c") 
 | fillnull total_events value="No Events Found"</query>
         </search>
-        <option name="count">10</option>
+        <option name="count">15</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">none</option>
         <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
@@ -235,9 +241,8 @@
         <fieldForValue>data_source</fieldForValue>
         <search base="basesearch">
           <query>
-| table data_source
-| dedup data_source
-| sort data_source</query>
+| stats count by data_source
+| fields - count</query>
         </search>
       </input>
       <input type="dropdown" token="mitre_tactic_token" searchWhenChanged="true">
@@ -249,9 +254,8 @@
         <fieldForValue>mitre_tactic</fieldForValue>
         <search base="basesearch">
           <query>
-| table mitre_tactic
-| dedup mitre_tactic
-| sort mitre_tactic</query>
+| stats count by mitre_tactic
+| fields - count</query>
         </search>
       </input>
       <input type="dropdown" token="mitre_technique_token" searchWhenChanged="true">
@@ -263,9 +267,8 @@
         <fieldForValue>mitre_technique</fieldForValue>
         <search base="basesearch">
           <query>
-| table mitre_technique
-| dedup mitre_technique
-| sort mitre_technique</query>
+| stats count by mitre_technique
+| fields - count</query>
         </search>
       </input>
       <input type="dropdown" token="risk_object" searchWhenChanged="true">
@@ -277,32 +280,28 @@
         <fieldForValue>risk_object</fieldForValue>
         <search base="basesearch">
           <query>
-| rex  field=risk_param max_match=0 "\"risk_object_field\":\"(?&lt;risk_object&gt;\w+)"
-| rex  field=risk_param max_match=0 "\"risk_object_type\":\"(?&lt;risk_object_type&gt;\w+)"
-| rex  field=risk_param max_match=0 "\"risk_score\":(?&lt;risk_score&gt;\d+)"
-
-|table risk_object
-|dedup risk_object
-|sort risk_object</query>
+| rex field=risk_param max_match=0 "\"risk_object_field\":\"(?&lt;risk_object&gt;\w+)"
+| rex field=risk_param max_match=0 "\"risk_object_type\":\"(?&lt;risk_object_type&gt;\w+)"
+| rex field=risk_param max_match=0 "\"risk_score\":(?&lt;risk_score&gt;\d+)"
+| table risk_object
+| dedup risk_object
+| sort risk_object</query>
         </search>
       </input>
       <table>
         <search base="basesearch">
           <query>
-| rename  action.risk.param._risk as risk_param action.risk.param._risk_object_type as risk_object_type0 action.risk.param._risk_object as risk_object0 action.risk.param._risk_score as risk_score0
-| rex  field=risk_param max_match=0 "\"risk_object_field\":\"(?&lt;risk_object&gt;\w+)"
-| rex  field=risk_param max_match=0 "\"risk_object_type\":\"(?&lt;risk_object_type&gt;\w+)"
-| rex  field=risk_param max_match=0 "\"risk_score\":(?&lt;risk_score&gt;\d+)"
-
+| rename action.risk.param._risk as risk_param action.risk.param._risk_object_type as risk_object_type0 action.risk.param._risk_object as risk_object0 action.risk.param._risk_score as risk_score0
+| rex field=risk_param max_match=0 "\"risk_object_field\":\"(?&lt;risk_object&gt;\w+)"
+| rex field=risk_param max_match=0 "\"risk_object_type\":\"(?&lt;risk_object_type&gt;\w+)"
+| rex field=risk_param max_match=0 "\"risk_score\":(?&lt;risk_score&gt;\d+)"
 | search actions=risk
 | eval risk_object=coalesce(risk_object, risk_object0)
 | eval risk_object_type=coalesce(risk_object_type, risk_object_type0)
 | eval risk_score=coalesce(risk_score, risk_score0)
 | eval data_source=coalesce(index, datamodel)
-
 | table title actions risk_param risk_object risk_object_type risk_score search index sourcetype datamodel mitre_technique mitre_tactic data_source
-|fillnull value="nothing listed"
-
+| fillnull value="nothing listed"
 | search data_source=$data_token$ AND mitre_tactic=$mitre_tactic_token$ AND mitre_technique=$mitre_technique_token$ AND risk_object=$risk_object$</query>
         </search>
         <option name="count">5</option>

--- a/dashboards/risk_attributions.xml
+++ b/dashboards/risk_attributions.xml
@@ -169,7 +169,12 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
               <set token="hide_asset">true</set>
             </condition>
           </progress>
-          <query>|inputlookup asset_lookup_by_str|search asset="$field_risk_object$"| appendcols [|from datamodel:"Risk"."All_Risk" |search risk_object="$field_risk_object$" risk_object_type="system"|stats sum(calculated_risk_score) as "Agg Risk Score"]</query>
+          <query>| inputlookup asset_lookup_by_str 
+| search asset="$field_risk_object$" 
+| appendcols 
+    [| from datamodel:"Risk"."All_Risk" 
+    | search risk_object="$field_risk_object$" risk_object_type="system" 
+    | stats sum(calculated_risk_score) as "Agg Risk Score"]</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -198,7 +203,13 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
               <set token="hide_identity">true</set>
             </condition>
           </progress>
-          <query>|inputlookup identity_lookup_expanded |search identity="$field_risk_object$"| eval startDate=strftime(startDate,"%m/%d/%y %H:%M:%S")| appendcols [|from datamodel:"Risk"."All_Risk" |search risk_object="$field_risk_object$" risk_object_type="user"|stats sum(calculated_risk_score) as "Agg Risk Score"]</query>
+          <query>| inputlookup identity_lookup_expanded 
+| search identity="$field_risk_object$" 
+| eval startDate=strftime(startDate,"%m/%d/%y %H:%M:%S") 
+| appendcols 
+    [| from datamodel:"Risk"."All_Risk" 
+    | search risk_object="$field_risk_object$" risk_object_type="user" 
+    | stats sum(calculated_risk_score) as "Agg Risk Score"]</query>
           <earliest>0</earliest>
           <latest>now</latest>
           <sampleRatio>1</sampleRatio>
@@ -219,7 +230,9 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <title>Risk Factors Matched</title>
       <table>
         <search>
-          <query>|tstats `summariesonly` values(All_Risk.risk_factor_mult_matched) as risk_factor_mult_matched values(All_Risk.risk_factor_add_matched) as risk_factor_add_matched from datamodel=Risk.All_Risk where All_Risk.risk_object="$field_risk_object$" by All_Risk.risk_object|eval risk_factors = mvappend('risk_factor_mult_matched', 'risk_factor_add_matched')|table risk_factors</query>
+          <query>| tstats `summariesonly` values(All_Risk.risk_factor_mult_matched) as risk_factor_mult_matched values(All_Risk.risk_factor_add_matched) as risk_factor_add_matched from datamodel=Risk.All_Risk where All_Risk.risk_object="$field_risk_object$" by All_Risk.risk_object 
+| eval risk_factors = mvappend('risk_factor_mult_matched', 'risk_factor_add_matched') 
+| table risk_factors</query>
           <earliest>0</earliest>
           <latest>now</latest>
           <sampleRatio>1</sampleRatio>
@@ -228,6 +241,7 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">none</option>
         <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
@@ -389,12 +403,12 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <title>Risk Attribution Timeline</title>
       <viz type="event-timeline-viz.event-timeline-viz">
         <search>
-          <query>| tstats `summariesonly` count values(source) as source from datamodel=Risk where All_Risk.risk_object="$field_risk_object$" source="*" by All_Risk.risk_message, _time span=15m
-|rename "All_Risk.risk_message" as risk_message
-|eval risk_message=if(len(risk_message)&gt;150,substr(risk_message,1,150)."..&lt;cut&gt;",risk_message)
-| eval source=replace(source,"^.*?-\sRR\s-\s(.*?)\s-\s\w+?\s-\sRule","\1")
-| table _time source risk_message threat_object
-| eval start=_time, label=source, tooltip=risk_message, data=threat_object
+          <query>| tstats `summariesonly` count values(source) as source from datamodel=Risk where All_Risk.risk_object="$field_risk_object$" source="*" by All_Risk.risk_message, _time span=15m 
+| rename "All_Risk.risk_message" as risk_message 
+| eval risk_message=if(len(risk_message)&gt;150,substr(risk_message,1,150)."..&lt;cut&gt;",risk_message) 
+| eval source=replace(source,"^.*?-\sRR\s-\s(.*?)\s-\s\w+?\s-\sRule","\1") 
+| table _time source risk_message threat_object 
+| eval start=_time, label=source, tooltip=risk_message, data=threat_object 
 | dedup _time label</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
@@ -411,17 +425,18 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <table>
         <title>&lt;click to drilldown to raw data&gt;</title>
         <search>
-          <query>| tstats `summariesonly` count min(_time) as _time values(All_Risk.risk_object) as risk_object from datamodel=Risk where All_Risk.risk_object="$field_risk_object$" source="*" by source, All_Risk.annotations.mitre_attack.mitre_tactic
-|rename "All_Risk.annotations.mitre_attack.mitre_tactic" as "ATT&amp;CK Tactic"
-| eval Rule=replace(source,"^.*?-\sRR\s-\s(.*?)\s-\s\w+?\s-\sRule","\1")
-|stats values("ATT&amp;CK Tactic") as "ATT&amp;CK Tactic" values(count) as count min(_time) as firstSeen values(risk_object) as risk_object by Rule, _time, source
-|lookup drilldown_searches.csv source
-|eval drilldown_search=replace(drilldown_search,"REPLACEME",risk_object)
-|sort firstSeen</query>
+          <query>| tstats `summariesonly` count min(_time) as _time values(All_Risk.risk_object) as risk_object from datamodel=Risk where All_Risk.risk_object="$field_risk_object$" source="*" by source, All_Risk.annotations.mitre_attack.mitre_tactic 
+| rename "All_Risk.annotations.mitre_attack.mitre_tactic" as "ATT&amp;CK Tactic" 
+| eval Rule=replace(source,"^.*?-\sRR\s-\s(.*?)\s-\s\w+?\s-\sRule","\1") 
+| stats values("ATT&amp;CK Tactic") as "ATT&amp;CK Tactic" values(count) as count min(_time) as firstSeen values(risk_object) as risk_object by Rule, _time, source 
+| lookup drilldown_searches.csv source 
+| eval drilldown_search=replace(drilldown_search,"REPLACEME",risk_object) 
+| sort firstSeen</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
+        <option name="refresh.display">progressbar</option>
         <fields>["Rule","ATT&amp;CK Tactic","count"]</fields>
         <drilldown>
           <link target="_blank">search?q=$row.drilldown_search$&amp;earliest=$timepicker.earliest$&amp;latest=$timepicker.latest$</link>
@@ -432,9 +447,10 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <table>
         <title>Related Threat Objects</title>
         <search>
-          <query>|from datamodel:Risk.All_Risk|search risk_object="$field_risk_object$"
-|sort _time
-|table threat_object_type,threat_object</query>
+          <query>| from datamodel:Risk.All_Risk 
+| search risk_object="$field_risk_object$" 
+| sort _time 
+| table threat_object_type,threat_object</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
         </search>
@@ -449,7 +465,11 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <table>
         <title>&lt;click to drilldown to pivot to new risk object&gt;</title>
         <search>
-          <query>|tstats `summariesonly` count, values(All_Risk.src) as src, values(All_Risk.dest) as dest, values(source) as source, values(All_Risk.risk_object_type) as risk_object_type values(All_Risk.user) as user from datamodel=Risk.All_Risk where All_Risk.user="$field_risk_object$" OR All_Risk.dest="$field_risk_object$" OR All_Risk.src="$field_risk_object$" OR All_Risk.threat_object="$field_risk_object$" All_Risk.risk_object!="$field_risk_object$" by All_Risk.risk_object|rename "All_Risk.risk_object" as risk_object|rex field=source "^.*?.-.RR.-.(?&lt;Rule&gt;.*?).-.\w+.-.Rule$"|fields - source|sort - count</query>
+          <query>| tstats `summariesonly` count, values(All_Risk.src) as src, values(All_Risk.dest) as dest, values(source) as source, values(All_Risk.risk_object_type) as risk_object_type values(All_Risk.user) as user from datamodel=Risk.All_Risk where All_Risk.user="$field_risk_object$" OR All_Risk.dest="$field_risk_object$" OR All_Risk.src="$field_risk_object$" OR All_Risk.threat_object="$field_risk_object$" All_Risk.risk_object!="$field_risk_object$" by All_Risk.risk_object 
+| rename "All_Risk.risk_object" as risk_object 
+| rex field=source "^.*?.-.RR.-.(?&lt;Rule&gt;.*?).-.\w+.-.Rule$" 
+| fields - source 
+| sort - count</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -458,6 +478,7 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">cell</option>
         <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>
@@ -470,7 +491,17 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <title>Notables for $field_risk_object$</title>
       <table>
         <search>
-          <query>`notable`|search risk_object="$field_risk_object$"|`notable_owners`|search _raw=*|rex field=_raw "search_name=.(?&lt;search_name&gt;[^\"]+)\""|table _time,owner,search_name</query>
+          <query>`notable` 
+| search 
+    [| inputlookup asset_lookup_by_str 
+    | search asset="$field_risk_object$" 
+    | table asset 
+    | rename asset as risk_object 
+    | format] 
+| `notable_owners` 
+| search _raw=* 
+| rex field=_raw "search_name=.(?&lt;search_name&gt;[^\"]+)\"" 
+| table _time,owner,search_name</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -491,14 +522,15 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <title>Risk Messages</title>
       <table>
         <search>
-          <query>|from datamodel:"Risk.All_Risk"
-|search risk_object="$field_risk_object$" search_name="* - RR - *"
-|table _time,risk_message
-|sort _time</query>
+          <query>| from datamodel:"Risk.All_Risk" 
+| search risk_object="$field_risk_object$" search_name="*" 
+| table _time, risk_message 
+| sort _time</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
         </search>
         <option name="drilldown">none</option>
+        <option name="refresh.display">progressbar</option>
       </table>
     </panel>
   </row>
@@ -507,9 +539,9 @@ by All_Risk.risk_object, All_Risk.risk_object_type, All_Risk.threat_object, All_
       <title>Risk Attributions</title>
       <event>
         <search>
-          <query>|from datamodel:"Risk.All_Risk"
-|search risk_object="$field_risk_object$" search_name="* - RR - *"
-|sort _time</query>
+          <query>| from datamodel:"Risk.All_Risk" 
+| search risk_object="$field_risk_object$" search_name="*" 
+| sort _time</query>
           <earliest>$timepicker.earliest$</earliest>
           <latest>$timepicker.latest$</latest>
           <sampleRatio>1</sampleRatio>

--- a/dashboards/risk_investigation.xml
+++ b/dashboards/risk_investigation.xml
@@ -20,7 +20,14 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
     <set token="search_filter">*</set>
   </init>
   <search id="base_search">
-    <query>| tstats summariesonly=t count values(All_Risk.risk_message) as risk_message values(All_Risk.risk_score) as risk_score values(All_Risk.savedsearch_description) as description values(All_Risk.annotations._all) as annotation values(source) as source values(All_Risk.src) as src values(All_Risk.user) as user values(All_Risk.threat_object) as threat_object from datamodel=Risk.All_Risk where All_Risk.risk_object=$field_rv$ groupby _time,All_Risk.risk_score,All_Risk.risk_message span=1s | table * | dedup _time risk_message </query>
+    <query>| tstats summariesonly=t count values(All_Risk.risk_message) as risk_message values(All_Risk.risk_score) as risk_score values(All_Risk.savedsearch_description) as description values(All_Risk.annotations._all) as annotation values(source) as source values(All_Risk.src) as src values(All_Risk.user) as user values(All_Risk.threat_object) as threat_object from datamodel=Risk.All_Risk where 
+    [| inputlookup asset_lookup_by_str 
+    | search asset="$field_rv$" 
+    | table asset 
+    | rename asset as All_Risk.risk_object 
+    | format] groupby _time,All_Risk.risk_score,All_Risk.risk_message span=1s 
+| table * 
+| dedup _time risk_message</query>
     <earliest>$timepicker.earliest$</earliest>
     <latest>$timepicker.latest$</latest>
   </search>
@@ -30,7 +37,11 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
     </query>
   </search>
   <search id="Count">
-    <query>| tstats summariesonly=t count as event_count from datamodel=Risk.All_Risk where All_Risk.risk_object=$field_rv$ groupby All_Risk.risk_object   </query>
+    <query>| tstats summariesonly=t count as event_count from datamodel=Risk.All_Risk where [| inputlookup asset_lookup_by_str 
+    | search asset="$field_rv$" 
+    | table asset 
+    | rename asset as All_Risk.risk_object 
+    | format] groupby All_Risk.risk_object</query>
     <earliest>-30d</earliest>
     <latest>now</latest>
     <progress>
@@ -38,7 +49,11 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
     </progress>
   </search>
   <search id="Threats">
-    <query>index=risk (NOT source="/opt/*" risk_object="$field_rv$")
+    <query>index=risk (NOT source="/opt/*" [| inputlookup asset_lookup_by_str 
+    | search asset="$field_rv$" 
+    | table asset 
+    | rename asset as risk_object 
+    | format])
 | stats count values(source) as source dc(risk_message) as risk_messages by threat_object
 | eventstats dc(threat_object) as dc_threats
 </query>
@@ -84,35 +99,6 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
         <latest>now</latest>
       </default>
     </input>
-<!-- 
-  <input type="link">
-      <choice value="context-clear">Risk Scoring Only</choice>
-      <choice value="context-full">Include 0 Risk Score Events</choice>
-      <default>context-clear</default>
-      <change>
-        <condition value="context-clear">
-          <set token="no_zero_risk_events">true</set>
-          <set token="no_zero_risk_messages"></set>
-          <set token="no_zero_risk_timeline">true</set>
-          <unset token="no_zero_risk_selection">false</unset>
-          <unset token="show_zero_risk_events"></unset>
-          <unset token="show_zero_risk_messages"></unset>
-          <unset token="show_zero_risk_timeline"></unset>
-          <unset token="show_zero_risk_selection"></unset>
-        </condition>
-        <condition value="context-full">
-          <set token="show_zero_risk_events">true</set>
-          <set token="show_zero_risk_messages"></set>
-          <set token="show_zero_risk_timeline">true</set>
-          <unset token="show_zero_risk_selection">false</unset>
-          <unset token="no_zero_risk_events"></unset>
-          <unset token="no_zero_risk_messages"></unset>
-          <unset token="no_zero_risk_timeline"></unset>
-          <unset token="no_zero_risk_selection"></unset>
-        </condition>
-      </change>
-    </input>
--->
   </fieldset>
   <row>
     <panel id="riskScore">
@@ -148,8 +134,11 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       </single>
       <single>
         <search>
-          <query>
-| makeresults | eval count = "$notable_count$" | eval count = if(isnum(count),count,"0")</query>
+          <query>| makeresults 
+| eval count = "$notable_count$" 
+| eval count = if(isnum(count),count,"0")</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
         <drilldown>
           <set token="check_notable"></set>
@@ -167,7 +156,10 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       <title>Risk Object Info</title>
       <table depends="$showUser$">
         <search>
-          <query>| inputlookup identity_lookup_expanded | search identity="$field_rv$" | table first last identity bunit startDate endDate watchlist_name | eval startDate=strftime(startDate,"%Y-%m-%d") , endDate=strftime(endDate,"%Y-%m-%d")</query>
+          <query>| inputlookup identity_lookup_expanded 
+| search identity="$field_rv$" 
+| table first last identity bunit startDate endDate watchlist_name 
+| eval startDate=strftime(startDate,"%Y-%m-%d") , endDate=strftime(endDate,"%Y-%m-%d")</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
         </search>
@@ -177,7 +169,9 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       </table>
       <table depends="$showSystem$">
         <search>
-          <query>| inputlookup asset_lookup_by_str | search nt_host="$field_rv$" | table wks_ip wks_usr wks_dom category city</query>
+          <query>| inputlookup asset_lookup_by_str 
+| search nt_host="$field_rv$" 
+| table wks_ip wks_usr wks_dom category city</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
         </search>
@@ -192,10 +186,19 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       <title>Notables for $field_rv$ in past 30 days</title>
       <table>
         <search>
-          <query>
-`get_notable_index` risk_object=$field_rv$
+          <!-- IR_Link changed to Static Name and Length which referrs to drilldown URL below.-->
+          <progress>
+            <set token="notable_count">$result.notable_count$</set>
+            <set token="incident_count">$result.incident_count$</set>
+          </progress>
+          <query>`get_notable_index` 
+    [| inputlookup asset_lookup_by_str 
+    | search asset="$field_rv$" 
+    | table asset 
+    | rename asset as risk_object 
+    | format] 
 | eval indexer_guid=replace('_bkt',".*~(.+)","\\1"), event_hash=md5(('_time' . '_raw')), event_id=((((indexer_guid . "@@") . index) . "@@") . event_hash), rule_id=event_id 
-| eval latest=_time + 1800, earliest=_time - 1800
+| eval latest=_time + 1800, earliest=_time - 1800 
 | search event_id="*" 
 | fields - "host_*" 
 | tags outputfield=tag 
@@ -216,47 +219,44 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
 | lookup update=true disposition_lookup _key as temp_disposition OUTPUT status as disposition,label as disposition_label,description as disposition_description,default as disposition_default 
 | eval disposition=if(isnull(disposition),"disposition:0",disposition), disposition_label=if(isnull(disposition_label),"Unassigned",disposition_label), disposition_description=if(isnull(disposition_description),"An error is preventing the event from having a valid disposition.",disposition_description), disposition_default=case(match(disposition_default,"1|[Tt]|[Tt][Rr][Uu][Ee]"),"true",match(disposition_default,"0|[Ff]|[Ff][Aa][Ll][Ss][Ee]"),"false",true(),disposition_default) 
 | fields - temp_disposition 
-| table _time, orig_time, search_name, orig_source, status_label, status_end, comment, owner, reviewer, risk_object, risk_object_type, risk_messages, src, user, dest, rule_id, event_hash, earliest, latest
-| eventstats count as notable_count count(eval(status_label="Incident")) as incident_count | eval incident_count = if(isnull(incident_count),"0",incident_count) | rename status_label as status
-| eval ir_link = "Click to View in Incident Review"
-| table _time, orig_time, search_name, orig_source, status_label, status_end, comment, owner, reviewer, risk_object, risk_object_type, risk_messages, src, user, dest, rule_id, event_hash, earliest, latest, ir_link, incident_count, status, notable_count
-</query>
-<!-- IR_Link changed to Static Name and Length which referrs to drilldown URL below.-->
+| table _time, orig_time, search_name, orig_source, status_label, status_end, comment, owner, reviewer, risk_object, risk_object_type, risk_messages, src, user, dest, rule_id, event_hash, earliest, latest 
+| eventstats count as notable_count count(eval(status_label="Incident")) as incident_count 
+| eval incident_count = if(isnull(incident_count),"0",incident_count) 
+| rename status_label as status 
+| eval ir_link = "Click to View in Incident Review" 
+| table _time, orig_time, search_name, orig_source, status_label, status_end, comment, owner, reviewer, risk_object, risk_object_type, risk_messages, src, user, dest, rule_id, event_hash, earliest, latest, ir_link, incident_count, status, notable_count</query>
           <earliest>-30d</earliest>
           <latest>now</latest>
-          <progress>
-            <set token="notable_count">$result.notable_count$</set>
-            <set token="incident_count">$result.incident_count$</set>
-          </progress>
         </search>
+        <option name="count">10</option>
+        <option name="refresh.display">progressbar</option>
+        <format type="color" field="comment">
+          <colorPalette type="list">[#a7c4f2]</colorPalette>
+        </format>
+        <fields>["_time","owner","status","comment","ir_link"]</fields>
         <drilldown>
-        <condition match="match('click.name2', &quot;ir_link&quot;)">
+          <condition match="match('click.name2', &quot;ir_link&quot;)">
             <link target="_blank">/app/SplunkEnterpriseSecuritySuite/incident_review?earliest=$row.earliest$&amp;latest=$row.latest$&amp;search=event_hash%3D$row.event_hash$</link>
-        </condition>
+          </condition>
           <condition>
             <unset token="check_notable"></unset>
           </condition>
         </drilldown>
-        <fields>_time owner status comment ir_link</fields>
-        <format type="color" field="comment">
-          <colorPalette type="list">[#a7c4f2]</colorPalette>
-        </format>
-        <option name="count">10</option>
-        <option name="refresh.display">progressbar</option>
       </table>
-  </panel>
+    </panel>
   </row>
   <row>
     <panel depends="$no_zero_risk_events$">
       <title>Event Breakdown</title>
       <table>
         <search base="no_zero_risk_events">
-          <query>| stats count as Events sum(risk_score) as risk_sum dc(risk_message) as "Distinct Events" values(description) as Description values(annotation) as Annotation by source | rename source as Rule | eval risk_sum = round(risk_sum,0) | rename risk_sum as "Risk Sum" | sort - "Risk Sum" </query>
+          <query>| stats count as Events sum(risk_score) as risk_sum dc(risk_message) as "Distinct Events" values(description) as Description values(annotation) as Annotation by source 
+| rename source as Rule 
+| eval risk_sum = round(risk_sum,0) 
+| rename risk_sum as "Risk Sum" 
+| sort - "Risk Sum"</query>
         </search>
-        <fields>"Events" "Risk Sum" "Rule" "Description" "Annotation"</fields>
-        <drilldown>
-          <set token="risk_rule_drilldown">$row.Rule$</set>
-        </drilldown>
+        <option name="refresh.display">progressbar</option>
         <format type="color" field="Risk Sum">
           <colorPalette type="minMidMax" maxColor="#eb441e" midColor="#ebe81e" minColor="#1eeb36"></colorPalette>
           <scale type="minMidMax" maxType="number" maxValue="80" midType="number" midValue="40" minType="number" minValue="0"></scale>
@@ -264,21 +264,27 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
         <format type="color" field="Rule">
           <colorPalette type="list">[#a7c4f2]</colorPalette>
         </format>
+        <fields>["Events","Risk Sum","Rule","Description","Annotation"]</fields>
+        <drilldown>
+          <set token="risk_rule_drilldown">$row.Rule$</set>
+        </drilldown>
       </table>
     </panel>
     <panel depends="$risk_rule_drilldown$">
       <table>
         <search>
-          <query>
-  | rest splunk_server=local count=0 /services/saved/searches 
-  | search title="$risk_rule_drilldown$" | rename dispatch.earliest_time as early_time
-  | table title qualifiedSearch early_time
-</query>
           <progress>
             <set token="qualifiedSearch">$result.qualifiedSearch$</set>
             <set token="earlySearch">$result.early_time$</set>
           </progress>
+          <query>| rest splunk_server=local count=0 /services/saved/searches f=title f=dispatch.earliest_time f=qualifiedSearch
+| search title="$risk_rule_drilldown$" 
+| rename dispatch.earliest_time as early_time 
+| table title qualifiedSearch early_time</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
+        <option name="refresh.display">progressbar</option>
         <format type="color" field="qualifiedSearch">
           <colorPalette type="list">[#a7c4f2]</colorPalette>
         </format>
@@ -298,8 +304,8 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       <title>Timeline of Events</title>
       <chart>
         <search base="no_zero_risk_search">
-          <query> | stats count as count by _time,risk_score,risk_message  | timechart span=30min limit=0 values(risk_score) as risk_score by risk_message
-        </query>
+          <query>| stats count as count by _time, risk_score, risk_message 
+| timechart span=30min limit=0 values(risk_score) as risk_score by risk_message</query>
         </search>
         <selection>
           <set token="selection.earliest">$start$</set>
@@ -322,19 +328,26 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
         <title>Risk Events</title>
         <search>
           <query>| makeresults 
-    | eval count="0" | eval count= if(isint($addriskmsg_count$),"$addriskmsg_count$",0)
-    | fields count | table count | sort - count </query>
+| eval count="0" 
+| eval count= if(isint($addriskmsg_count$),"$addriskmsg_count$",0) 
+| fields count 
+| table count 
+| sort - count</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
+        <option name="drilldown">all</option>
+        <option name="height">50</option>
+        <option name="rangeColors">["0xdc4e41","0x3c444d"]</option>
+        <option name="rangeValues">[1000]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="useColors">1</option>
         <drilldown>
           <set token="no_zero_risk_messages"></set>
           <unset token="threat_object_panel"></unset>
           <unset token="threat_token"></unset>
           <unset token="no_zero_risk_selection"></unset>
         </drilldown>
-        <option name="height">50</option>
-        <option name="rangeColors">["0xdc4e41","0x3c444d"]</option>
-        <option name="rangeValues">[1000]</option>
-        <option name="useColors">1</option>
       </single>
     </panel>
     <panel>
@@ -342,19 +355,26 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
         <title>Threat Objects</title>
         <search>
           <query>| makeresults 
-    | eval count="0" | eval count= if(isint($dc_threats$),"$dc_threats$",0)
-    | fields count | table count | sort - count </query>
+| eval count="0" 
+| eval count= if(isint($dc_threats$),"$dc_threats$",0) 
+| fields count 
+| table count 
+| sort - count</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
+        <option name="drilldown">all</option>
+        <option name="height">50</option>
+        <option name="rangeColors">["0xdc4e41","0x3c444d"]</option>
+        <option name="rangeValues">[1000]</option>
+        <option name="refresh.display">progressbar</option>
+        <option name="useColors">1</option>
         <drilldown>
           <set token="threat_object_panel"></set>
           <unset token="no_zero_risk_messages"></unset>
           <unset token="threat_token"></unset>
           <unset token="no_zero_risk_selection"></unset>
         </drilldown>
-        <option name="height">50</option>
-        <option name="rangeColors">["0xdc4e41","0x3c444d"]</option>
-        <option name="rangeValues">[1000]</option>
-        <option name="useColors">1</option>
       </single>
     </panel>
   </row>
@@ -388,20 +408,20 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
     <panel>
       <table depends="$no_zero_risk_messages$">
         <search base="no_zero_risk_events" id="no_zero_risk_search">
-          <query>
-            | eval risk_score = round(risk_score)
-| eval risk_message = risk_score." - ".risk_message
-| eval latest=_time + 1800, earliest=_time - 5400
-| table _time source risk_message risk_score threat_object threat_short earliest latest
-| sort + _time
-| eventstats count(risk_message) as riskmsg_count
-| search $search_filter$ | eventstats count(risk_message) as addriskmsg_count
-          </query>
           <progress>
             <set token="addriskmsg_count">$result.addriskmsg_count$</set>
           </progress>
+          <query>| eval risk_score = round(risk_score) 
+| eval risk_message = risk_score." - ".risk_message 
+| eval latest=_time + 1800, earliest=_time - 5400 
+| table _time source risk_message risk_score threat_object threat_short earliest latest 
+| sort + _time 
+| eventstats count(risk_message) as riskmsg_count 
+| search $search_filter$ 
+| eventstats count(risk_message) as addriskmsg_count</query>
         </search>
         <option name="count">10</option>
+        <option name="refresh.display">progressbar</option>
         <format type="color" field="threat_object">
           <colorPalette type="list">[#a7c4f2]</colorPalette>
         </format>
@@ -422,7 +442,7 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
         </drilldown>
       </table>
     </panel>
-  <panel>
+    <panel>
       <table depends="$no_zero_risk_selection$">
         <search base="no_zero_risk_search" id="no_zero_risk_search_selection">
           <query>
@@ -433,6 +453,7 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
           </progress>
         </search>
         <option name="count">10</option>
+        <option name="refresh.display">progressbar</option>
         <format type="color" field="threat_object">
           <colorPalette type="list">[#a7c4f2]</colorPalette>
         </format>
@@ -462,11 +483,14 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       <single>
         <title>Number of Events</title>
         <search>
-          <query>| makeresults | eval num_objects = if(isint($num_objects$),"$num_objects$",0) | table num_objects
-          </query>
+          <query>| makeresults 
+| eval num_objects = if(isint($num_objects$),"$num_objects$",0) 
+| table num_objects</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
         <drilldown>
-            <unset token="threat_token"></unset>
+          <unset token="threat_token"></unset>
         </drilldown>
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
@@ -484,10 +508,14 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       <single>
         <title>Risk Rule Sources</title>
         <search>
-          <query>| makeresults | eval source_count = if(isint($source_count$),"$source_count$",0) | table source_count</query>
+          <query>| makeresults 
+| eval source_count = if(isint($source_count$),"$source_count$",0) 
+| table source_count</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
         <drilldown>
-            <unset token="threat_token"></unset>
+          <unset token="threat_token"></unset>
         </drilldown>
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
@@ -506,13 +534,13 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
         <title>Risk Objects</title>
         <search>
           <query>| makeresults 
-| eval risk_objects = if(isint($ro_count$),"$ro_count$",0)
+| eval risk_objects = if(isint($ro_count$),"$ro_count$",0) 
 | table risk_objects</query>
           <earliest>$earliest$</earliest>
           <latest>$latest$</latest>
         </search>
         <drilldown>
-            <unset token="threat_token"></unset>
+          <unset token="threat_token"></unset>
         </drilldown>
         <option name="colorBy">value</option>
         <option name="colorMode">none</option>
@@ -530,20 +558,26 @@ I've left the input toggle commented out so you can add it in if you'd like. -->
       <table>
         <title>Past 30 Days for $threat_token$</title>
         <search id="threat_breakdown">
-          <query>| tstats summariesonly=t count values(All_Risk.risk_message) as risk_message values(All_Risk.risk_score) as risk_score values(source) as sources values(All_Risk.risk_object_type) as risk_object_type from datamodel=Risk.All_Risk where All_Risk.threat_object="$threat_token$" groupby All_Risk.risk_object _time span=30d | rename All_Risk.risk_object as risk_object | table * | eval risk_score = mvindex(risk_score,0) , risk_score=round(risk_score,0) , risk_message = mvindex(risk_message,0) , risk_message = risk_score." - ".risk_message | eventstats dc(risk_object) as ro_count dc(sources) as source_count sum(count) as num_objects | rename risk_message AS sample_message </query>
-          <earliest>-30d</earliest>
-          <latest></latest>
-          <sampleRatio>1</sampleRatio>
           <progress>
             <set token="ro_count">$result.ro_count$</set>
             <set token="source_count">$result.source_count$</set>
             <set token="num_objects">$result.num_objects$</set>
           </progress>
+          <query>| tstats summariesonly=t count values(All_Risk.risk_message) as risk_message values(All_Risk.risk_score) as risk_score values(source) as sources values(All_Risk.risk_object_type) as risk_object_type from datamodel=Risk.All_Risk where All_Risk.threat_object="$threat_token$" groupby All_Risk.risk_object _time span=30d 
+| rename All_Risk.risk_object as risk_object 
+| table * 
+| eval risk_score = mvindex(risk_score,0) , risk_score=round(risk_score,0) , risk_message = mvindex(risk_message,0) , risk_message = risk_score." - ".risk_message 
+| eventstats dc(risk_object) as ro_count dc(sources) as source_count sum(count) as num_objects 
+| rename risk_message AS sample_message</query>
+          <earliest>-30d</earliest>
+          <latest></latest>
+          <sampleRatio>1</sampleRatio>
         </search>
         <option name="count">20</option>
         <option name="dataOverlayMode">none</option>
         <option name="drilldown">cell</option>
         <option name="percentagesRow">false</option>
+        <option name="refresh.display">progressbar</option>
         <option name="rowNumbers">false</option>
         <option name="totalsRow">false</option>
         <option name="wrap">true</option>

--- a/dashboards/risk_notable_analysis_dashboard.xml
+++ b/dashboards/risk_notable_analysis_dashboard.xml
@@ -14,44 +14,54 @@
       <table>
         <title>Risk Rules</title>
         <search>
-          <query>| tstats summariesonly=false sum(All_Risk.calculated_risk_score) as risk_score,dc(All_Risk.risk_object) as risk_objects,count from datamodel=Risk.All_Risk where *  All_Risk.risk_object_type="*" (All_Risk.risk_object="*" OR risk_object="*") by source | sort 1000 - count,risk_score</query>
+          <query>| tstats summariesonly=false sum(All_Risk.calculated_risk_score) as risk_score, dc(All_Risk.risk_object) as risk_objects, dc(All_Risk.threat_object) as threat_objects count from datamodel=Risk.All_Risk where * All_Risk.risk_object_type="*" (All_Risk.risk_object="*" OR risk_object="*") by source 
+| sort 1000 - count,risk_score</query>
           <earliest>$time_picker.earliest$</earliest>
           <latest>$time_picker.latest$</latest>
         </search>
         <option name="drilldown">cell</option>
-        <drilldown>
-          <set token="risk_drilldown">$click.value$</set>
-        </drilldown>
+        <option name="refresh.display">progressbar</option>
         <format type="color" field="risk_score">
           <colorPalette type="minMidMax" maxColor="#e34a33" midColor="#fdbb84" minColor="#fee8c8"></colorPalette>
           <scale type="minMidMax" maxType="number" maxValue="1000" midType="number" midValue="500" minType="number" minValue="0"></scale>
         </format>
+        <drilldown>
+          <set token="risk_drilldown">$click.value$</set>
+        </drilldown>
       </table>
     </panel>
     <panel>
       <table>
         <title>Risk Rule Frequency</title>
         <search>
-          <query>`notable` | search eventtype=risk_notables | eventstats count as sum | stats count(eval(status_label="New")) as rule_count values(sum) as sum by orig_source | eval notable_percent = rule_count / sum | sort - notable_percent</query>
+          <query>`notable` 
+| search eventtype=risk_notables 
+| eventstats count as sum 
+| stats count(eval(status_label="New")) as rule_count values(sum) as sum by orig_source 
+| eval notable_percent = rule_count / sum 
+| sort - notable_percent</query>
           <earliest>$time_picker.earliest$</earliest>
           <latest>$time_picker.latest$</latest>
         </search>
         <option name="drilldown">none</option>
+        <option name="refresh.display">progressbar</option>
       </table>
     </panel>
     <panel depends="$doesnt_exist$">
       <table>
         <search>
-          <query>
-  | rest splunk_server=local count=0 /services/saved/searches 
-  | search title="$risk_drilldown$" | rename dispatch.earliest_time as early_time qualifiedSearch as search_spl
-  | table search_spl early_time
-          </query>
           <done>
             <set token="search_spl">$result.search_spl$</set>
             <set token="early_time">$result.early_time$</set>
           </done>
+          <query>| rest splunk_server=local count=0 /services/saved/searches f=title f= dispatch.earliest_time f=qualifiedSearch
+| search title="$risk_drilldown$" 
+| rename dispatch.earliest_time as early_time qualifiedSearch as search_spl 
+| table search_spl early_time</query>
+          <earliest>$earliest$</earliest>
+          <latest>$latest$</latest>
         </search>
+        <option name="refresh.display">progressbar</option>
       </table>
     </panel>
   </row>

--- a/dashboards/risk_notable_analysis_dashboard.xml
+++ b/dashboards/risk_notable_analysis_dashboard.xml
@@ -38,7 +38,7 @@
 | search eventtype=risk_notables 
 | eventstats count as sum 
 | stats count(eval(status_label="New")) as rule_count values(sum) as sum by orig_source 
-| eval notable_percent = rule_count / sum 
+| eval notable_percent = (rule_count / sum) * 100
 | sort - notable_percent</query>
           <earliest>$time_picker.earliest$</earliest>
           <latest>$time_picker.latest$</latest>
@@ -54,7 +54,7 @@
             <set token="search_spl">$result.search_spl$</set>
             <set token="early_time">$result.early_time$</set>
           </done>
-          <query>| rest splunk_server=local count=0 /services/saved/searches f=title f= dispatch.earliest_time f=qualifiedSearch
+          <query>| rest splunk_server=local count=0 /services/saved/searches f=title f=dispatch.earliest_time f=qualifiedSearch
 | search title="$risk_drilldown$" 
 | rename dispatch.earliest_time as early_time qualifiedSearch as search_spl 
 | table search_spl early_time</query>


### PR DESCRIPTION
Closes issue #102.

I've fixed a lot of other small issues, including:

- Broken panels
- Reworked some panels to remove the overly restrictive filter on Risk Rules being actually named `RR-*`, instead including any detection that has the `Risk Analysis` adaptive response action
- In some panels, we would not properly support all Asset names (from A&I) so I added that - e.g. we would match "hostname" but not "hostname.domain", or the assigned IP address, etc.  We should do the same for Identities in another PR.
- Formatted SPL
- Added key fields when missing, reworked chart formats in some cases to make them easier to read, etc.

Note: The `Risk Attribution (Investigative View)` dashboard still has issues, which I'll document into another issue entry.